### PR TITLE
Setup Github action to publish hugo site to a branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,48 @@
+# Workflow to build and deploy site to Github Pages using Hugo
+
+# Name of Workflow
+name: github pages
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ main ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "deploy"
+  deploy:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+
+      # Step 1 - Checks-out your repository under $GITHUB_WORKSPACE
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true  # Fetch Hugo themes
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+
+      # Step 2 - Sets up the latest version of Hugo
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: 'latest'
+
+      # Step 3 - Clean and don't fail
+      - name: Clean public directory
+        run: rm -rf public
+
+      # Step 4 - Builds the site using the latest version of Hugo
+      - name: Build
+        run: hugo
+
+      # Step 5 - Push our generated site to our gh-pages branch
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.GH_PUBLISHING_TOKEN }}
+          publish_dir: ./public


### PR DESCRIPTION
This change adds a Github action workflow to build the hugo site and publish the results to a branch called `gh_pages`

resolves #5 